### PR TITLE
Add an entrypoint that allow starting yarn scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:10.15.1-slim
 
+COPY docker/docker-entrypoint.sh docker/docker-is-script.js /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
 RUN userdel node
 
 ARG UID=1000
@@ -10,4 +13,4 @@ WORKDIR /usr/src/project
 
 ENV PATH="/usr/src/project/node_modules/.bin:${PATH}"
 
-CMD ["yarn", "start"]
+CMD ["start"]

--- a/README.MD
+++ b/README.MD
@@ -11,7 +11,7 @@ yarn start
 docker-compose up -d
 docker-compose stop app
 docker-compose run --rm app yarn install
-docker-compose run --rm app yarn sequelize db:migrate
+docker-compose run --rm app sequelize db:migrate
 docker-compose start app
 ```
 
@@ -56,7 +56,7 @@ And then run `docker-compose build` to rebuild your containers.
 yarn lint
 
 # run in docker
-docker-compose run --rm app yarn lint
+docker-compose run --rm app lint
 ```
 
 ### build the app

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if docker-is-script.js "${1}"; then
+  set -- yarn "$@"
+fi
+
+exec "$@"

--- a/docker/docker-is-script.js
+++ b/docker/docker-is-script.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+let directory = process.cwd();
+
+const { root } = path.parse(directory);
+
+while (!fs.existsSync(`${directory}/package.json`)) {
+    if (directory === root) {
+        process.exit(2);
+    }
+
+    directory = path.dirname(directory);
+}
+
+// eslint-disable-next-line global-require, import/no-dynamic-require
+process.exit(process.argv[2] in require(`${directory}/package.json`).scripts ? 0 : 1);


### PR DESCRIPTION
L'idée est de pouvoir lancer directement les scripts listés dans le `package.json` par example : `docker-compose run --rm app lint`