### PR TITLE
[Sequelize] 🐛 remove deprecated in v5 operatorsAliases

### DIFF
--- a/api/db.config.js
+++ b/api/db.config.js
@@ -5,7 +5,6 @@ module.exports = {
     dialectOptions: {
         ssl: '1' === process.env.DATABASE_SSL,
     },
-    operatorsAliases: false,
     username: process.env.DATABASE_USER,
     password: process.env.DATABASE_PASSWORD,
     database: process.env.DATABASE_NAME,


### PR DESCRIPTION
À partir de la version 5, Sequelize met operatorsAliases à false par default donc plus besoin de le mettre (et en plus ça génère un warning deprecated 😅).

Lien vers un ticket d'explication : [Lien](https://github.com/sequelize/sequelize/issues/8417#issuecomment-461150731)