### PR TITLE
Fix: Production Dockerfile

### DIFF
--- a/.production/Dockerfile
+++ b/.production/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH="/usr/src/app/node_modules/.bin:${PATH}"
 COPY package.json yarn.lock ./
 RUN yarn install
 
-COPY babel.config.js index.html ./
+COPY babel.config.js ./
 COPY tools ./tools
 COPY api ./api
 COPY app ./app


### PR DESCRIPTION
This PR fixes production Dockerfile.
During build, it tries to copy `index.html` file which was removed in https://github.com/thetribeio/node-react-starter-kit/pull/25

**Steps to reproduce:**

Running:

```
docker build -f .production/Dockerfile -t prod-test .
```

throws: 

```
Step 6/22 : COPY babel.config.js index.html ./
COPY failed: stat /var/lib/docker/tmp/docker-builder477210087/index.html: no such file or directory
```

