### PR TITLE
Disable WDS contentBase option

### DIFF
--- a/tools/start.js
+++ b/tools/start.js
@@ -77,6 +77,7 @@ async function start() {
 
     // webpack dev server (with HMR)
     const devServer = new WebpackDevServer(clientCompiler, {
+        contentBase: false,
         disableHostCheck: true,
         compress: true,
         clientLogLevel: 'none',


### PR DESCRIPTION
We setup express static middleware ourselves so the content base option is not needed.

This will fix sending POST request to the API until [the related bug](https://github.com/webpack/webpack-dev-server/issues/2370) is fixed in webpack-dev-server.