### PR TITLE
Remove dependency on mkdirp

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "import-fresh": "^3.2.1",
     "jest": "^25.1.0",
     "mini-css-extract-plugin": "^0.9.0",
-    "mkdirp": "^0.5.1",
     "null-loader": "^3.0.0",
     "react-deep-force-update": "^2.1.3",
     "react-dev-utils": "^10.0.0",

--- a/tools/lib/fs.js
+++ b/tools/lib/fs.js
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 import glob from 'glob';
-import mkdirp from 'mkdirp';
 import rimraf from 'rimraf';
 
 export const copyFile = (source, target) => new Promise((resolve, reject) => {
@@ -34,9 +33,7 @@ export const readDir = (pattern, options) => new Promise((resolve, reject) => gl
     (err, result) => (err ? reject(err) : resolve(result)),
 ));
 
-export const makeDir = (name) => new Promise((resolve, reject) => {
-    mkdirp(name, (err) => (err ? reject(err) : resolve()));
-});
+export const makeDir = (name) => fs.promises.mkdir(name, { recursive: true });
 
 export const copyDir = async (source, target) => {
     const dirs = await readDir('**/*.*', {


### PR DESCRIPTION
`fs.mkdir` already support creating directories recursively, so no need have a dependency for it.