### PR TITLE
Udpate ReadMe docker-compose.override.yml

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -51,7 +51,7 @@ You may create a file `docker-compose.override.yml` at the root to override your
 Most likely you might be interested in opening a port on the host, or use your yarn cache in docker containers.
 
 ```yaml
-version: '2.0'
+version: '2.4'
 services:
   app:
     volumes:


### PR DESCRIPTION
With the current docker-compose.override.yml file you would get this error

`ERROR: Version mismatch: file ./docker-compose.yml specifies version 2.4 but extension file ./docker-compose.override.yml uses version 2.0`